### PR TITLE
cmd/gomobile: keep the module version information as much as possible

### DIFF
--- a/cmd/gomobile/bind.go
+++ b/cmd/gomobile/bind.go
@@ -263,17 +263,14 @@ func getModuleVersions(targetOS string, targetArch string, src string) (*modfile
 			return nil, err
 		}
 		if mod != nil {
-			switch {
-			case mod.Replace != nil:
+			if mod.Replace != nil {
 				p, v := mod.Replace.Path, mod.Replace.Version
 				if modfile.IsDirectoryPath(p) {
 					// replaced by a local directory
 					p = mod.Replace.Dir
 				}
 				f.AddReplace(mod.Path, mod.Version, p, v)
-			case mod.Main, mod.Path == "golang.org/x/mobile":
-				// We are binding this module or it has
-				// explicit dependency on golang.org/x/mobile.
+			} else {
 				// When the version part is empty, the module is local and mod.Dir represents the location.
 				if v := mod.Version; v == "" {
 					f.AddReplace(mod.Path, mod.Version, mod.Dir, "")


### PR DESCRIPTION
Before this change, the main module specifies the module version of the
package to bind, the version might not be adopted by gomobile because
gomobile trims some dependencies information. If a dependency is not
a main module nor a replaced module, the dependency information is
omitted.

For example, if you have this go.mod in a workspace:

    module example.com/m

    requier (
        github.com/foo/bar v0.1.0-123456
    )

and then run `gomobile bind github.com/foo/bar` there, the specified
version might not be used because github.com/foo/bar is not a main nor
a replaced module.

This change keeps the dependency information as much as possible
to avoid this confusion.

Updates golang/go#37048

Change-Id: I875a1b9485438bdee336f3fc2d131775353004f5
Reviewed-on: https://go-review.googlesource.com/c/mobile/+/226279
Reviewed-by: Hyang-Ah Hana Kim <hyangah@gmail.com>